### PR TITLE
Alias "removeListener" as "off" in Redis emitter

### DIFF
--- a/packages/@uppy/companion/src/server/emitter/redis-emitter.js
+++ b/packages/@uppy/companion/src/server/emitter/redis-emitter.js
@@ -94,6 +94,16 @@ module.exports = (redisClient, redisPubSubScope) => {
   }
 
   /**
+   * Remove an event listener
+   *
+   * @param {string} eventName name of the event
+   * @param {any} handler the handler of the event
+   */
+  function off (eventName, handler) {
+    return removeListener(eventName, handler)
+  }
+
+  /**
    * Add an event listener (will be triggered at most once)
    *
    * @param {string} eventName name of the event
@@ -130,6 +140,7 @@ module.exports = (redisClient, redisPubSubScope) => {
 
   return {
     on,
+    off,
     once,
     emit,
     removeListener,


### PR DESCRIPTION
This makes the Redis emitter API consistent with the Node emitter API and the documentation.

Fixes #4646